### PR TITLE
Centralize API error handling with error kind classification

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -116,7 +116,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -672,7 +671,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -716,7 +714,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2314,7 +2311,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3494,7 +3490,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4121,7 +4116,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4589,7 +4583,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4709,7 +4702,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4819,7 +4811,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4833,7 +4824,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/fe/src/api.ts
+++ b/fe/src/api.ts
@@ -71,18 +71,20 @@ async function safeApiCall<T>(
     const response = await apiCall();
 
     if (response === undefined) {
-      return failure({ message: errorMessage });
+      return failure({ kind: "unknown", message: errorMessage });
     }
 
     return success(response);
   } catch (maybeApiError: unknown) {
     if (maybeApiError instanceof DefaultApiError) {
       return failure({
+        kind: "unknown",
         message: errorMessage,
         cause: maybeApiError,
       });
     } else {
       return failure({
+        kind: "unknown",
         message: `${errorMessage} in general`,
         cause: maybeApiError as Error,
       });

--- a/fe/src/clientContext.test.tsx
+++ b/fe/src/clientContext.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@testing-library/preact";
-import { expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { MinesApiClient } from "./api";
-import { ClientProvider, useApiClient } from "./clientContext";
+import { ClientProvider, useApiClient, withErrorLogging } from "./clientContext";
+import { success, failure } from "./result";
 
 test("useApiClient returns client within ClientProvider", () => {
   let client: MinesApiClient | undefined;
@@ -29,4 +30,60 @@ test("useApiClient throws error outside ClientProvider", () => {
   expect(() => render(<TestComponent />)).toThrow(
     "useApiClient must be used within a ClientProvider",
   );
+});
+
+describe("withErrorLogging", () => {
+  const mockClient: MinesApiClient = {
+    fetchMatch: vi.fn(),
+    startNewGame: vi.fn(),
+    makeMove: vi.fn(),
+  };
+
+  test("passes through successful results without logging", async () => {
+    const value = { id: "abc", lives: 3 };
+    vi.mocked(mockClient.fetchMatch).mockResolvedValue(success(value));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapped = withErrorLogging(mockClient);
+
+    const result = await wrapped.fetchMatch("abc");
+
+    expect(result).toEqual(success(value));
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  test("logs to console.error on failure and returns the failure", async () => {
+    const cause = new Error("network down");
+    vi.mocked(mockClient.makeMove).mockResolvedValue(
+      failure({ message: "Move failed", cause }),
+    );
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapped = withErrorLogging(mockClient);
+
+    const result = await wrapped.makeMove("abc", { x: 0, y: 0 } as any);
+
+    expect(result.success).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith("Move failed", cause);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("logs to console.error on failure without cause", async () => {
+    vi.mocked(mockClient.startNewGame).mockResolvedValue(
+      failure({ message: "Server error" }),
+    );
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapped = withErrorLogging(mockClient);
+
+    const result = await wrapped.startNewGame({ difficulty: "beginner" } as any);
+
+    expect(result.success).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith("Server error", undefined);
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/fe/src/clientContext.test.tsx
+++ b/fe/src/clientContext.test.tsx
@@ -1,11 +1,17 @@
+import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { render } from "@testing-library/preact";
 import { describe, expect, test, vi } from "vitest";
 import type { MinesApiClient } from "./api";
-import { ClientProvider, useApiClient, withErrorLogging } from "./clientContext";
-import { success, failure } from "./result";
+import {
+  ClientProvider,
+  type GameClient,
+  useApiClient,
+  wrapClient,
+} from "./clientContext";
+import { failure, success } from "./result";
 
 test("useApiClient returns client within ClientProvider", () => {
-  let client: MinesApiClient | undefined;
+  let client: GameClient | undefined;
 
   const TestComponent = () => {
     client = useApiClient();
@@ -32,7 +38,7 @@ test("useApiClient throws error outside ClientProvider", () => {
   );
 });
 
-describe("withErrorLogging", () => {
+describe("wrapClient", () => {
   const mockClient: MinesApiClient = {
     fetchMatch: vi.fn(),
     startNewGame: vi.fn(),
@@ -44,7 +50,7 @@ describe("withErrorLogging", () => {
     vi.mocked(mockClient.fetchMatch).mockResolvedValue(success(value));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrapped = withErrorLogging(mockClient);
+    const wrapped = wrapClient(mockClient);
 
     const result = await wrapped.fetchMatch("abc");
 
@@ -54,35 +60,71 @@ describe("withErrorLogging", () => {
     consoleSpy.mockRestore();
   });
 
-  test("logs to console.error on failure and returns the failure", async () => {
+  test("logs to console.error on failure and returns ApiError with unknown kind", async () => {
     const cause = new Error("network down");
     vi.mocked(mockClient.makeMove).mockResolvedValue(
       failure({ message: "Move failed", cause }),
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrapped = withErrorLogging(mockClient);
+    const wrapped = wrapClient(mockClient);
 
     const result = await wrapped.makeMove("abc", { x: 0, y: 0 } as any);
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toEqual({ kind: "unknown", message: "Move failed" });
+    }
     expect(consoleSpy).toHaveBeenCalledWith("Move failed", cause);
 
     consoleSpy.mockRestore();
   });
 
-  test("logs to console.error on failure without cause", async () => {
-    vi.mocked(mockClient.startNewGame).mockResolvedValue(
-      failure({ message: "Server error" }),
+  test("translates 422 DefaultApiError to match_over kind", async () => {
+    const apiError = new DefaultApiError("Match over");
+    apiError.responseStatusCode = 422;
+
+    vi.mocked(mockClient.makeMove).mockResolvedValue(
+      failure({ message: "Move failed", cause: apiError }),
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrapped = withErrorLogging(mockClient);
+    const wrapped = wrapClient(mockClient);
 
-    const result = await wrapped.startNewGame({ difficulty: "beginner" } as any);
+    const result = await wrapped.makeMove("abc", { x: 0, y: 0 } as any);
 
     expect(result.success).toBe(false);
-    expect(consoleSpy).toHaveBeenCalledWith("Server error", undefined);
+    if (!result.success) {
+      expect(result.error).toEqual({
+        kind: "match_over",
+        message: "Move failed",
+      });
+    }
+    expect(consoleSpy).toHaveBeenCalledWith("Move failed", apiError);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("translates non-422 DefaultApiError to unknown kind", async () => {
+    const apiError = new DefaultApiError("Conflict");
+    apiError.responseStatusCode = 409;
+
+    vi.mocked(mockClient.fetchMatch).mockResolvedValue(
+      failure({ message: "Fetch failed", cause: apiError }),
+    );
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapped = wrapClient(mockClient);
+
+    const result = await wrapped.fetchMatch("abc");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toEqual({
+        kind: "unknown",
+        message: "Fetch failed",
+      });
+    }
 
     consoleSpy.mockRestore();
   });

--- a/fe/src/clientContext.test.tsx
+++ b/fe/src/clientContext.test.tsx
@@ -2,16 +2,11 @@ import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { render } from "@testing-library/preact";
 import { describe, expect, test, vi } from "vitest";
 import type { MinesApiClient } from "./api";
-import {
-  ClientProvider,
-  type GameClient,
-  useApiClient,
-  wrapClient,
-} from "./clientContext";
+import { ClientProvider, useApiClient, wrapClient } from "./clientContext";
 import { failure, success } from "./result";
 
 test("useApiClient returns client within ClientProvider", () => {
-  let client: GameClient | undefined;
+  let client: MinesApiClient | undefined;
 
   const TestComponent = () => {
     client = useApiClient();
@@ -60,10 +55,10 @@ describe("wrapClient", () => {
     consoleSpy.mockRestore();
   });
 
-  test("logs to console.error on failure and returns ApiError with unknown kind", async () => {
+  test("logs to console.error on failure and preserves unknown kind", async () => {
     const cause = new Error("network down");
     vi.mocked(mockClient.makeMove).mockResolvedValue(
-      failure({ message: "Move failed", cause }),
+      failure({ kind: "unknown", message: "Move failed", cause }),
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -73,7 +68,7 @@ describe("wrapClient", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toEqual({ kind: "unknown", message: "Move failed" });
+      expect(result.error.kind).toBe("unknown");
     }
     expect(consoleSpy).toHaveBeenCalledWith("Move failed", cause);
 
@@ -85,7 +80,7 @@ describe("wrapClient", () => {
     apiError.responseStatusCode = 422;
 
     vi.mocked(mockClient.makeMove).mockResolvedValue(
-      failure({ message: "Move failed", cause: apiError }),
+      failure({ kind: "unknown", message: "Move failed", cause: apiError }),
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -95,22 +90,19 @@ describe("wrapClient", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toEqual({
-        kind: "match_over",
-        message: "Move failed",
-      });
+      expect(result.error.kind).toBe("match_over");
     }
     expect(consoleSpy).toHaveBeenCalledWith("Move failed", apiError);
 
     consoleSpy.mockRestore();
   });
 
-  test("translates non-422 DefaultApiError to unknown kind", async () => {
+  test("preserves unknown kind for non-422 DefaultApiError", async () => {
     const apiError = new DefaultApiError("Conflict");
     apiError.responseStatusCode = 409;
 
     vi.mocked(mockClient.fetchMatch).mockResolvedValue(
-      failure({ message: "Fetch failed", cause: apiError }),
+      failure({ kind: "unknown", message: "Fetch failed", cause: apiError }),
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -120,10 +112,7 @@ describe("wrapClient", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toEqual({
-        kind: "unknown",
-        message: "Fetch failed",
-      });
+      expect(result.error.kind).toBe("unknown");
     }
 
     consoleSpy.mockRestore();

--- a/fe/src/clientContext.tsx
+++ b/fe/src/clientContext.tsx
@@ -2,20 +2,11 @@ import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { type ComponentChildren, createContext } from "preact";
 import { useContext, useRef } from "preact/hooks";
 import { type MinesApiClient, makeNewApiClient } from "./api";
-import type { MoveDto, NewGameDto } from "./client/models/req";
-import type { MatchstateDto } from "./client/models/res";
-import type { ApiError, Result } from "./result";
+import type { Result } from "./result";
 
-export interface GameClient {
-  fetchMatch(matchId: string): Promise<Result<MatchstateDto, ApiError>>;
-  startNewGame(newGame: NewGameDto): Promise<Result<MatchstateDto, ApiError>>;
-  makeMove(
-    matchId: string,
-    move: MoveDto,
-  ): Promise<Result<MatchstateDto, ApiError>>;
-}
-
-export const ClientContext = createContext<GameClient | undefined>(undefined);
+export const ClientContext = createContext<MinesApiClient | undefined>(
+  undefined,
+);
 
 interface ClientProviderProps {
   children: ComponentChildren;
@@ -23,7 +14,7 @@ interface ClientProviderProps {
 }
 
 export function ClientProvider({ children, apiBaseUrl }: ClientProviderProps) {
-  const clientRef = useRef<GameClient>(
+  const clientRef = useRef<MinesApiClient>(
     wrapClient(makeNewApiClient(apiBaseUrl)),
   );
 
@@ -34,18 +25,19 @@ export function ClientProvider({ children, apiBaseUrl }: ClientProviderProps) {
   );
 }
 
-export function wrapClient(client: MinesApiClient): GameClient {
-  async function wrapCall<T>(
-    call: Promise<Result<T>>,
-  ): Promise<Result<T, ApiError>> {
+export function wrapClient(client: MinesApiClient): MinesApiClient {
+  async function wrapCall<T>(call: Promise<Result<T>>): Promise<Result<T>> {
     const result = await call;
-    if (result.success) {
-      return result;
+    if (!result.success) {
+      if (
+        result.error.cause instanceof DefaultApiError &&
+        result.error.cause.responseStatusCode === 422
+      ) {
+        result.error.kind = "match_over";
+      }
+      console.error(result.error.message, result.error.cause);
     }
-
-    const apiError = toApiError(result.error);
-    console.error(result.error.message, result.error.cause);
-    return { success: false, error: apiError };
+    return result;
   }
 
   return {
@@ -55,17 +47,7 @@ export function wrapClient(client: MinesApiClient): GameClient {
   };
 }
 
-function toApiError(problem: { message: string; cause?: Error }): ApiError {
-  if (
-    problem.cause instanceof DefaultApiError &&
-    problem.cause.responseStatusCode === 422
-  ) {
-    return { kind: "match_over", message: problem.message };
-  }
-  return { kind: "unknown", message: problem.message };
-}
-
-export function useApiClient(): GameClient {
+export function useApiClient(): MinesApiClient {
   const context = useContext(ClientContext);
 
   if (context === undefined) {

--- a/fe/src/clientContext.tsx
+++ b/fe/src/clientContext.tsx
@@ -1,6 +1,7 @@
 import { type ComponentChildren, createContext } from "preact";
 import { useContext, useRef } from "preact/hooks";
 import { type MinesApiClient, makeNewApiClient } from "./api";
+import type { Result } from "./result";
 
 export const ClientContext = createContext<MinesApiClient | undefined>(
   undefined,
@@ -12,13 +13,31 @@ interface ClientProviderProps {
 }
 
 export function ClientProvider({ children, apiBaseUrl }: ClientProviderProps) {
-  const clientRef = useRef<MinesApiClient>(makeNewApiClient(apiBaseUrl));
+  const clientRef = useRef<MinesApiClient>(
+    withErrorLogging(makeNewApiClient(apiBaseUrl)),
+  );
 
   return (
     <ClientContext.Provider value={clientRef.current}>
       {children}
     </ClientContext.Provider>
   );
+}
+
+export function withErrorLogging(client: MinesApiClient): MinesApiClient {
+  async function wrapCall<T>(call: Promise<Result<T>>): Promise<Result<T>> {
+    const result = await call;
+    if (!result.success) {
+      console.error(result.error.message, result.error.cause);
+    }
+    return result;
+  }
+
+  return {
+    fetchMatch: (matchId) => wrapCall(client.fetchMatch(matchId)),
+    startNewGame: (newGame) => wrapCall(client.startNewGame(newGame)),
+    makeMove: (matchId, move) => wrapCall(client.makeMove(matchId, move)),
+  };
 }
 
 export function useApiClient(): MinesApiClient {

--- a/fe/src/clientContext.tsx
+++ b/fe/src/clientContext.tsx
@@ -1,11 +1,21 @@
+import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { type ComponentChildren, createContext } from "preact";
 import { useContext, useRef } from "preact/hooks";
 import { type MinesApiClient, makeNewApiClient } from "./api";
-import type { Result } from "./result";
+import type { MoveDto, NewGameDto } from "./client/models/req";
+import type { MatchstateDto } from "./client/models/res";
+import type { ApiError, Result } from "./result";
 
-export const ClientContext = createContext<MinesApiClient | undefined>(
-  undefined,
-);
+export interface GameClient {
+  fetchMatch(matchId: string): Promise<Result<MatchstateDto, ApiError>>;
+  startNewGame(newGame: NewGameDto): Promise<Result<MatchstateDto, ApiError>>;
+  makeMove(
+    matchId: string,
+    move: MoveDto,
+  ): Promise<Result<MatchstateDto, ApiError>>;
+}
+
+export const ClientContext = createContext<GameClient | undefined>(undefined);
 
 interface ClientProviderProps {
   children: ComponentChildren;
@@ -13,8 +23,8 @@ interface ClientProviderProps {
 }
 
 export function ClientProvider({ children, apiBaseUrl }: ClientProviderProps) {
-  const clientRef = useRef<MinesApiClient>(
-    withErrorLogging(makeNewApiClient(apiBaseUrl)),
+  const clientRef = useRef<GameClient>(
+    wrapClient(makeNewApiClient(apiBaseUrl)),
   );
 
   return (
@@ -24,13 +34,18 @@ export function ClientProvider({ children, apiBaseUrl }: ClientProviderProps) {
   );
 }
 
-export function withErrorLogging(client: MinesApiClient): MinesApiClient {
-  async function wrapCall<T>(call: Promise<Result<T>>): Promise<Result<T>> {
+export function wrapClient(client: MinesApiClient): GameClient {
+  async function wrapCall<T>(
+    call: Promise<Result<T>>,
+  ): Promise<Result<T, ApiError>> {
     const result = await call;
-    if (!result.success) {
-      console.error(result.error.message, result.error.cause);
+    if (result.success) {
+      return result;
     }
-    return result;
+
+    const apiError = toApiError(result.error);
+    console.error(result.error.message, result.error.cause);
+    return { success: false, error: apiError };
   }
 
   return {
@@ -40,7 +55,17 @@ export function withErrorLogging(client: MinesApiClient): MinesApiClient {
   };
 }
 
-export function useApiClient(): MinesApiClient {
+function toApiError(problem: { message: string; cause?: Error }): ApiError {
+  if (
+    problem.cause instanceof DefaultApiError &&
+    problem.cause.responseStatusCode === 422
+  ) {
+    return { kind: "match_over", message: problem.message };
+  }
+  return { kind: "unknown", message: problem.message };
+}
+
+export function useApiClient(): GameClient {
   const context = useContext(ClientContext);
 
   if (context === undefined) {

--- a/fe/src/hooks/useGameState.test.tsx
+++ b/fe/src/hooks/useGameState.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { useGameState } from "./useGameState";
 import { ClientContext } from "../clientContext";
 import { MovetypeObject } from "../client/models/matchmaking";
-import { type ApiError, success } from "../result";
+import { type Problem, success } from "../result";
 
 // Mock useLocation
 const mockRoute = vi.fn();
@@ -47,7 +47,7 @@ describe("useGameState", () => {
 
   it("should handle error when fetching game fails", async () => {
     const gameId = "game-123";
-    const error: ApiError = { kind: "unknown", message: "Error fetching game" };
+    const error: Problem = { kind: "unknown", message: "Error fetching game" };
     mockClient.fetchMatch.mockResolvedValue({ success: false, error });
 
     const { result } = renderHook(() => useGameState(gameId), { wrapper });
@@ -183,7 +183,7 @@ describe("useGameState", () => {
 
     mockClient.fetchMatch.mockResolvedValue(success(initialGameState));
 
-    const error: ApiError = { kind: "match_over", message: "Move failed" };
+    const error: Problem = { kind: "match_over", message: "Move failed" };
     mockClient.makeMove.mockResolvedValue({ success: false, error });
 
     const { result } = renderHook(() => useGameState(gameId), { wrapper });

--- a/fe/src/hooks/useGameState.test.tsx
+++ b/fe/src/hooks/useGameState.test.tsx
@@ -3,8 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { useGameState } from "./useGameState";
 import { ClientContext } from "../clientContext";
 import { MovetypeObject } from "../client/models/matchmaking";
-import { success, failure } from "../result";
-import { DefaultApiError } from "@microsoft/kiota-abstractions";
+import { type ApiError, success } from "../result";
 
 // Mock useLocation
 const mockRoute = vi.fn();
@@ -48,9 +47,8 @@ describe("useGameState", () => {
 
   it("should handle error when fetching game fails", async () => {
     const gameId = "game-123";
-    mockClient.fetchMatch.mockResolvedValue(
-      failure({ message: "Error fetching game" })
-    );
+    const error: ApiError = { kind: "unknown", message: "Error fetching game" };
+    mockClient.fetchMatch.mockResolvedValue({ success: false, error });
 
     const { result } = renderHook(() => useGameState(gameId), { wrapper });
 
@@ -59,7 +57,6 @@ describe("useGameState", () => {
     });
 
     expect(result.current.gameState).toBeNull();
-    // Error logging is mocked/console.error, not asserting on console.error here but verifying state
   });
 
   it("should redirect to game-over if lives are 0 on fetch", async () => {
@@ -176,7 +173,7 @@ describe("useGameState", () => {
     expect(mockRoute).toHaveBeenCalledWith("/game-over");
   });
 
-  it("should redirect to game-over on 422 error during move", async () => {
+  it("should redirect to game-over on match_over error during move", async () => {
     const gameId = "game-123";
     const initialGameState = {
         lives: 1,
@@ -186,14 +183,8 @@ describe("useGameState", () => {
 
     mockClient.fetchMatch.mockResolvedValue(success(initialGameState));
 
-    const apiError = new Error("422 Error");
-    (apiError as any).responseStatusCode = 422;
-    const defaultApiError = new DefaultApiError("422 Error");
-    defaultApiError.responseStatusCode = 422;
-
-    mockClient.makeMove.mockResolvedValue(
-        failure({ message: "Move failed", cause: defaultApiError })
-    );
+    const error: ApiError = { kind: "match_over", message: "Move failed" };
+    mockClient.makeMove.mockResolvedValue({ success: false, error });
 
     const { result } = renderHook(() => useGameState(gameId), { wrapper });
 

--- a/fe/src/hooks/useGameState.ts
+++ b/fe/src/hooks/useGameState.ts
@@ -31,8 +31,6 @@ export function useGameState(gameId: string | null) {
           return;
         }
         setGameState(result.value);
-      } else {
-        console.error(result.error);
       }
     };
 
@@ -57,15 +55,11 @@ export function useGameState(gameId: string | null) {
       if (result.value.lives === 0) {
         route("/game-over");
       }
-    } else {
-      if (
-        result.error.cause instanceof DefaultApiError &&
-        result.error.cause.responseStatusCode === 422
-      ) {
-        route("/game-over");
-      } else {
-        console.error(result.error);
-      }
+    } else if (
+      result.error.cause instanceof DefaultApiError &&
+      result.error.cause.responseStatusCode === 422
+    ) {
+      route("/game-over");
     }
   };
 

--- a/fe/src/hooks/useGameState.ts
+++ b/fe/src/hooks/useGameState.ts
@@ -3,6 +3,7 @@ import { useLocation } from "preact-iso";
 import { MovetypeObject } from "../client/models/matchmaking";
 import type { MatchstateDto } from "../client/models/res";
 import { useApiClient } from "../clientContext";
+import { isMatchOver } from "../result";
 
 export function useGameState(gameId: string | null) {
   const { route } = useLocation();
@@ -54,7 +55,7 @@ export function useGameState(gameId: string | null) {
       if (result.value.lives === 0) {
         route("/game-over");
       }
-    } else if (result.error.kind === "match_over") {
+    } else if (isMatchOver(result)) {
       route("/game-over");
     }
   };

--- a/fe/src/hooks/useGameState.ts
+++ b/fe/src/hooks/useGameState.ts
@@ -1,4 +1,3 @@
-import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { useEffect, useState } from "preact/hooks";
 import { useLocation } from "preact-iso";
 import { MovetypeObject } from "../client/models/matchmaking";
@@ -55,10 +54,7 @@ export function useGameState(gameId: string | null) {
       if (result.value.lives === 0) {
         route("/game-over");
       }
-    } else if (
-      result.error.cause instanceof DefaultApiError &&
-      result.error.cause.responseStatusCode === 422
-    ) {
+    } else if (result.error.kind === "match_over") {
       route("/game-over");
     }
   };

--- a/fe/src/pages/Game/index.test.tsx
+++ b/fe/src/pages/Game/index.test.tsx
@@ -1,11 +1,9 @@
-import { DefaultApiError } from "@microsoft/kiota-abstractions";
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { LocationProvider } from "preact-iso";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { MinesApiClient } from "../../api";
 import { CellstateObject } from "../../client/models/board";
 import { MovetypeObject } from "../../client/models/matchmaking";
-import { ClientContext } from "../../clientContext";
+import { ClientContext, type GameClient } from "../../clientContext";
 import { Game } from "./index";
 
 // Mock dependencies
@@ -20,14 +18,14 @@ vi.mock("preact-iso", async () => {
 });
 
 describe("Game Page", () => {
-  let mockClient: MinesApiClient;
+  let mockClient: GameClient;
 
   beforeEach(() => {
     mockClient = {
       fetchMatch: vi.fn(),
       startNewGame: vi.fn(),
       makeMove: vi.fn(),
-    } as unknown as MinesApiClient;
+    } as unknown as GameClient;
   });
 
   const renderGame = () => {
@@ -64,7 +62,7 @@ describe("Game Page", () => {
   it("should display error message if game load fails", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: false,
-      error: "Failed to fetch",
+      error: { kind: "unknown", message: "Failed to fetch" },
     });
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -189,18 +187,15 @@ describe("Game Page", () => {
     });
   });
 
-  it("redirects to game over on 422 error", async () => {
+  it("redirects to game over on match_over error", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
     });
 
-    const error = new DefaultApiError("Match over");
-    error.responseStatusCode = 422;
-
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
-      error: { cause: error },
+      error: { kind: "match_over", message: "Match over" },
     });
 
     renderGame();
@@ -213,18 +208,15 @@ describe("Game Page", () => {
     });
   });
 
-  it("does not redirect on 409 error", async () => {
+  it("does not redirect on unknown error", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
     });
 
-    const error = new DefaultApiError("Concurrent update");
-    error.responseStatusCode = 409;
-
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
-      error: { cause: error },
+      error: { kind: "unknown", message: "Concurrent update" },
     });
 
     renderGame();
@@ -302,18 +294,15 @@ describe("Game Page", () => {
     });
   });
 
-  it("redirects to game over on 422 error from right-click", async () => {
+  it("redirects to game over on match_over error from right-click", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
     });
 
-    const error = new DefaultApiError("Match over");
-    error.responseStatusCode = 422;
-
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
-      error: { cause: error },
+      error: { kind: "match_over", message: "Match over" },
     });
 
     renderGame();
@@ -326,18 +315,15 @@ describe("Game Page", () => {
     });
   });
 
-  it("does not redirect on general error from right-click", async () => {
+  it("does not redirect on unknown error from right-click", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
     });
 
-    const error = new DefaultApiError("General error");
-    error.responseStatusCode = 500;
-
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
-      error: { cause: error },
+      error: { kind: "unknown", message: "General error" },
     });
 
     renderGame();

--- a/fe/src/pages/Game/index.test.tsx
+++ b/fe/src/pages/Game/index.test.tsx
@@ -213,7 +213,7 @@ describe("Game Page", () => {
     });
   });
 
-  it("logs error on 409 and does not redirect", async () => {
+  it("does not redirect on 409 error", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
@@ -221,7 +221,6 @@ describe("Game Page", () => {
 
     const error = new DefaultApiError("Concurrent update");
     error.responseStatusCode = 409;
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
@@ -234,10 +233,9 @@ describe("Game Page", () => {
     fireEvent.click(screen.getAllByRole("button")[0]);
 
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockClient.makeMove).toHaveBeenCalled();
     });
     expect(mockRoute).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
   });
 
   it("handles cell right-click and calls makeMove with Flag type", async () => {
@@ -328,7 +326,7 @@ describe("Game Page", () => {
     });
   });
 
-  it("logs error on general error from right-click", async () => {
+  it("does not redirect on general error from right-click", async () => {
     (mockClient.fetchMatch as any).mockResolvedValue({
       success: true,
       value: mockGameState,
@@ -336,8 +334,6 @@ describe("Game Page", () => {
 
     const error = new DefaultApiError("General error");
     error.responseStatusCode = 500;
-
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     (mockClient.makeMove as any).mockResolvedValue({
       success: false,
@@ -351,11 +347,9 @@ describe("Game Page", () => {
     fireEvent.contextMenu(screen.getAllByRole("button")[0]);
 
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockClient.makeMove).toHaveBeenCalled();
     });
 
     expect(mockRoute).not.toHaveBeenCalled();
-
-    consoleSpy.mockRestore();
   });
 });

--- a/fe/src/pages/Game/index.test.tsx
+++ b/fe/src/pages/Game/index.test.tsx
@@ -3,7 +3,8 @@ import { LocationProvider } from "preact-iso";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CellstateObject } from "../../client/models/board";
 import { MovetypeObject } from "../../client/models/matchmaking";
-import { ClientContext, type GameClient } from "../../clientContext";
+import type { MinesApiClient } from "../../api";
+import { ClientContext } from "../../clientContext";
 import { Game } from "./index";
 
 // Mock dependencies
@@ -18,14 +19,14 @@ vi.mock("preact-iso", async () => {
 });
 
 describe("Game Page", () => {
-  let mockClient: GameClient;
+  let mockClient: MinesApiClient;
 
   beforeEach(() => {
     mockClient = {
       fetchMatch: vi.fn(),
       startNewGame: vi.fn(),
       makeMove: vi.fn(),
-    } as unknown as GameClient;
+    } as unknown as MinesApiClient;
   });
 
   const renderGame = () => {

--- a/fe/src/pages/Home/index.tsx
+++ b/fe/src/pages/Home/index.tsx
@@ -22,7 +22,6 @@ export function Home() {
       // Navigate to the game page with the new game id
       route(`/game?id=${matchId}`);
     } else {
-      console.error(result.error);
       setLoading(false);
     }
   };

--- a/fe/src/result.test.ts
+++ b/fe/src/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { failure, type Problem, type Result, success } from "./result";
+import { failure, isMatchOver, type Problem, type Result, success } from "./result";
 
 describe("Result Pattern", () => {
   it("should create a success result with a value", () => {
@@ -46,5 +46,21 @@ describe("Result Pattern", () => {
 
     expect(processResult(success("ok"))).toBe("Success: ok");
     expect(processResult(failure({ kind: "unknown", message: "fail" }))).toBe("Error: fail");
+  });
+});
+
+describe("isMatchOver", () => {
+  it("should return true for match_over failures", () => {
+    const result = failure({ kind: "match_over", message: "Game ended" });
+    if (!result.success) {
+      expect(isMatchOver(result)).toBe(true);
+    }
+  });
+
+  it("should return false for unknown failures", () => {
+    const result = failure({ kind: "unknown", message: "Server error" });
+    if (!result.success) {
+      expect(isMatchOver(result)).toBe(false);
+    }
   });
 });

--- a/fe/src/result.test.ts
+++ b/fe/src/result.test.ts
@@ -14,7 +14,7 @@ describe("Result Pattern", () => {
   });
 
   it("should create a failure result with a problem", () => {
-    const problem: Problem = { message: "Something went wrong" };
+    const problem: Problem = { kind: "unknown", message: "Something went wrong" };
     const result = failure(problem);
 
     expect(result.success).toBe(false);
@@ -27,7 +27,7 @@ describe("Result Pattern", () => {
 
   it("should support optional cause in Problem", () => {
     const cause = new Error("Root cause");
-    const problem: Problem = { message: "Wrapped error", cause };
+    const problem: Problem = { kind: "unknown", message: "Wrapped error", cause };
     const result = failure(problem);
 
     if (!result.success) {
@@ -45,6 +45,6 @@ describe("Result Pattern", () => {
     };
 
     expect(processResult(success("ok"))).toBe("Success: ok");
-    expect(processResult(failure({ message: "fail" }))).toBe("Error: fail");
+    expect(processResult(failure({ kind: "unknown", message: "fail" }))).toBe("Error: fail");
   });
 });

--- a/fe/src/result.ts
+++ b/fe/src/result.ts
@@ -31,3 +31,7 @@ export function failure<T = never>(problem: Problem): Result<T> {
     error: problem,
   };
 }
+
+export function isMatchOver(result: Failure): boolean {
+  return result.error.kind === "match_over";
+}

--- a/fe/src/result.ts
+++ b/fe/src/result.ts
@@ -1,4 +1,7 @@
+export type ErrorKind = "match_over" | "unknown";
+
 export interface Problem {
+  kind: ErrorKind;
   message: string;
   cause?: Error;
 }
@@ -8,19 +11,12 @@ export interface Success<T> {
   value: T;
 }
 
-export interface Failure<E = Problem> {
+export interface Failure {
   success: false;
-  error: E;
+  error: Problem;
 }
 
-export type Result<T, E = Problem> = Success<T> | Failure<E>;
-
-export type ErrorKind = "match_over" | "unknown";
-
-export interface ApiError {
-  kind: ErrorKind;
-  message: string;
-}
+export type Result<T> = Success<T> | Failure;
 
 export function success<T>(value: T): Result<T> {
   return {
@@ -29,9 +25,9 @@ export function success<T>(value: T): Result<T> {
   };
 }
 
-export function failure<T = never, E = Problem>(error: E): Result<T, E> {
+export function failure<T = never>(problem: Problem): Result<T> {
   return {
     success: false,
-    error,
+    error: problem,
   };
 }

--- a/fe/src/result.ts
+++ b/fe/src/result.ts
@@ -8,12 +8,19 @@ export interface Success<T> {
   value: T;
 }
 
-export interface Failure {
+export interface Failure<E = Problem> {
   success: false;
-  error: Problem;
+  error: E;
 }
 
-export type Result<T> = Success<T> | Failure;
+export type Result<T, E = Problem> = Success<T> | Failure<E>;
+
+export type ErrorKind = "match_over" | "unknown";
+
+export interface ApiError {
+  kind: ErrorKind;
+  message: string;
+}
 
 export function success<T>(value: T): Result<T> {
   return {
@@ -22,9 +29,9 @@ export function success<T>(value: T): Result<T> {
   };
 }
 
-export function failure<T = never>(problem: Problem): Result<T> {
+export function failure<T = never, E = Problem>(error: E): Result<T, E> {
   return {
     success: false,
-    error: problem,
+    error,
   };
 }


### PR DESCRIPTION
## Summary
This PR refactors error handling across the application by introducing a centralized error classification system. Instead of checking HTTP status codes throughout the codebase, errors are now classified by `kind` ("match_over" or "unknown") at the API client wrapper level, simplifying error handling logic in consuming code.

## Key Changes

- **Added error kind classification**: Introduced `ErrorKind` type with "match_over" and "unknown" variants to the `Problem` interface in `result.ts`

- **Created `wrapClient` function**: Implemented a new wrapper in `clientContext.tsx` that:
  - Intercepts all API client calls
  - Translates 422 HTTP status codes from `DefaultApiError` to `match_over` error kind
  - Logs all errors to `console.error` with message and cause
  - Returns the classified error to callers

- **Simplified error handling in hooks**: Updated `useGameState.ts` to use the new `isMatchOver()` helper function instead of checking `DefaultApiError` instances and status codes directly

- **Removed redundant error logging**: Eliminated duplicate error logging from `useGameState.ts` and `Home/index.tsx` since the wrapper now handles all logging centrally

- **Updated all test mocks**: Modified test files to use the new error structure with `kind` field, making tests more maintainable and aligned with the new error classification system

## Implementation Details

The `wrapClient` function wraps each API client method and provides a consistent error handling layer. This approach:
- Keeps HTTP-specific error translation logic in one place
- Ensures all errors are logged consistently
- Makes the error kind available to all consumers without additional checks
- Simplifies testing by allowing tests to mock errors with the expected structure

https://claude.ai/code/session_01KCsKw3w1GmWsJg5eQe8dDx